### PR TITLE
Fix for ssl configuration variable names

### DIFF
--- a/templates/rabbitmq.config.erb
+++ b/templates/rabbitmq.config.erb
@@ -22,9 +22,9 @@
      <% if @ssl %>
      {ssl_listeners, [<%= @ssl_port %>]},
      {ssl_options, 
-         [{ca_cert_file,"/etc/rabbitmq/ssl/cacert.pem"},
-             {cert_file,"/etc/rabbitmq/ssl/server_cert.pem"},
-             {key_file,"/etc/rabbitmq/ssl/server_key.pem"},
+         [{cacertfile,"/etc/rabbitmq/ssl/cacert.pem"},
+             {certfile,"/etc/rabbitmq/ssl/server_cert.pem"},
+             {keyfile,"/etc/rabbitmq/ssl/server_key.pem"},
              {verify,verify_none},
              {fail_if_no_peer_cert,false}]},
      <% else %>


### PR DESCRIPTION
We need to revert this because i've changed these variable names used by rabbitmq by mistake. These are the only ones without the underscore.

@rberrelleza 
@arnaud-elasticbox 
