### PR TITLE
Reduce Heartbeat to 25secs

### DIFF
--- a/templates/rabbitmq.config.erb
+++ b/templates/rabbitmq.config.erb
@@ -11,7 +11,7 @@
      {default_user_tags,[administrator]},
      {default_vhost,<<"/">>},
      {delegate_count,16},
-     {heartbeat,120},
+     {heartbeat,25},
      {frame_max,131072},
      {hipe_compile,false},
      {disk_free_limit,500000000},


### PR DESCRIPTION
Increase heartbeat to every 25 secs to reduce AMQ timeouts.
